### PR TITLE
MANTA-4752 eliminate all #master deps in package.json files (start tagging releases)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
-# Changelog
+# node-buckets-mdapi changelog
 
-## v0.1.0 Forked from [node-moray](https://github.com/joyent/node-moray). Please
-  see the `node-moray` [CHANGES
-  file](https://github.com/joyent/node-moray/CHANGES.md) for the history of
-  `node-moray` changes prior to this fork.
+## 0.1.0
+
+Forked from [node-moray](https://github.com/joyent/node-moray). Please see the
+`node-moray` [CHANGES file](https://github.com/joyent/node-moray/CHANGES.md) for
+the history of `node-moray` changes prior to this fork.

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,6 @@ MAN_OUTROOT	= ./man
 include ./tools/mk/Makefile.manpages.defs
 
 include ./tools/mk/Makefile.defs
-include ./tools/mk/Makefile.smf.defs
 
 #
 # Repo-specific targets
@@ -57,6 +56,15 @@ include ./tools/mk/Makefile.smf.defs
 .PHONY: all
 all: $(REPO_DEPS)
 	$(NPM) rebuild
+
+# "Cutting a release" is just tagging the current commit with
+# "v(package.json version)".
+.PHONY: cutarelease
+cutarelease:
+	which json 2>/dev/null 1>/dev/null  # Ensure have the 'json' tool.
+	ver=$(shell json -f package.json version) && \
+	    git tag "v$$ver" && \
+	    git push origin "v$$ver"
 
 #
 # Manual pages are checked into this repository.  See Makefile.manpages.defs for


### PR DESCRIPTION
I'll tag v0.1.0 using `make cutarelease` after getting this in.