### PR TITLE
MANTA-4341 Optimize conditional object operations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # node-buckets-mdapi changelog
 
+## 0.7.0
+
+Add support for conditional requests
+
 ## 0.6.0
 
 Add support for garbage collection

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # node-buckets-mdapi changelog
 
+## 0.6.0
+
+Backwards compatible support for a separate precondition object in the
+`getObject`, `updateObject`, and `deleteObject` calls.
+
 ## 0.4.0
 
 Complete renaming work from boray to buckets-mdapi

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,5 @@
 # node-buckets-mdapi changelog
 
-## 0.6.0
-
-Backwards compatible support for a separate precondition object in the
-`getObject`, `updateObject`, and `deleteObject` calls.
-
 ## 0.4.0
 
 Complete renaming work from boray to buckets-mdapi

--- a/lib/client.js
+++ b/lib/client.js
@@ -712,12 +712,7 @@ BucketsMdapiClient.prototype.deleteBucket =
 BucketsMdapiClient.prototype.createObject =
     function createObject(owner, bucket_id,
     name, object_id, content_length, content_md5, content_type, headers,
-    sharks, props, vnode, req_id, precondition, cb) {
-
-    if (cb === undefined && typeof (precondition) === 'function') {
-        cb = precondition;
-        precondition = {};
-    }
+    sharks, props, vnode, precondition, req_id, cb) {
 
     assert.string(owner, 'owner');
     assert.string(bucket_id, 'bucket_id');
@@ -730,13 +725,14 @@ BucketsMdapiClient.prototype.createObject =
     assert.number(vnode, 'vnode');
     assert.string(req_id, 'req_id');
     assert.optionalObject(props, 'props');
+    assert.optionalObject(precondition, 'precondition');
     assert.func(cb, 'callback');
 
     var rpcctx = this.ctxCreateForCallback(cb);
     if (rpcctx) {
         objects.createObject(rpcctx, owner, bucket_id, name, object_id,
             content_length, content_md5, content_type, headers, sharks, props,
-            vnode, req_id, precondition, this.makeReleaseCb(rpcctx, cb));
+            vnode, precondition, req_id, this.makeReleaseCb(rpcctx, cb));
     }
 };
 
@@ -766,13 +762,8 @@ BucketsMdapiClient.prototype.createObject =
  */
 BucketsMdapiClient.prototype.updateObject =
     function updateObject(owner, bucket_id,
-    name, object_id, content_type, headers, props, vnode, req_id, precondition,
+    name, object_id, content_type, headers, props, vnode, precondition, req_id,
     cb) {
-
-    if (cb === undefined && typeof (precondition) === 'function') {
-        cb = precondition;
-        precondition = {};
-    }
 
     assert.string(owner, 'owner');
     assert.string(bucket_id, 'bucket_id');
@@ -782,13 +773,13 @@ BucketsMdapiClient.prototype.updateObject =
     assert.number(vnode, 'vnode');
     assert.optionalObject(props, 'props');
     assert.string(req_id, 'req_id');
-    assert.object(precondition, 'precondition');
+    assert.optionalObject(precondition, 'precondition');
     assert.func(cb, 'callback');
 
     var rpcctx = this.ctxCreateForCallback(cb);
     if (rpcctx) {
         objects.updateObject(rpcctx, owner, bucket_id, name, object_id,
-        content_type, headers, props, vnode, req_id, precondition,
+        content_type, headers, props, vnode, precondition, req_id,
         this.makeReleaseCb(rpcctx, cb));
     }
 };
@@ -809,26 +800,21 @@ BucketsMdapiClient.prototype.updateObject =
  * @param {Function} cb            - callback
  */
 BucketsMdapiClient.prototype.getObject =
-    function getObject(owner, bucket_id, name, vnode, req_id, precondition,
+    function getObject(owner, bucket_id, name, vnode, precondition, req_id,
     cb) {
-
-    if (cb === undefined && typeof (precondition) === 'function') {
-        cb = precondition;
-        precondition = {};
-    }
 
     assert.string(owner, 'owner');
     assert.string(bucket_id, 'bucket_id');
     assert.string(name, 'name');
     assert.number(vnode, 'vnode');
+    assert.optionalObject(precondition, 'precondition');
     assert.string(req_id, 'req_id');
-    assert.object(precondition, 'precondition');
     assert.func(cb, 'callback');
 
     var rpcctx = this.ctxCreateForCallback(cb);
     if (rpcctx) {
-        objects.getObject(rpcctx, owner, bucket_id, name, vnode, req_id,
-            precondition, this.makeReleaseCb(rpcctx, cb));
+        objects.getObject(rpcctx, owner, bucket_id, name, vnode, precondition,
+            req_id, this.makeReleaseCb(rpcctx, cb));
     }
 };
 
@@ -878,26 +864,21 @@ BucketsMdapiClient.prototype.listObjects =
  * @param {Function} cb            - callback
  */
 BucketsMdapiClient.prototype.deleteObject =
-    function deleteObject(owner, bucket_id, name, vnode, req_id, precondition,
+    function deleteObject(owner, bucket_id, name, vnode, precondition, req_id,
     cb) {
-
-    if (cb === undefined && typeof (precondition) === 'function') {
-        cb = precondition;
-        precondition = {};
-    }
 
     assert.string(owner, 'owner');
     assert.string(bucket_id, 'bucket_id');
     assert.string(name, 'name');
     assert.number(vnode, 'vnode');
     assert.string(req_id, 'req_id');
-    assert.object(precondition, 'precondition');
+    assert.optionalObject(precondition, 'precondition');
     assert.func(cb, 'callback');
 
     var rpcctx = this.ctxCreateForCallback(cb);
     if (rpcctx) {
-        objects.deleteObject(rpcctx, owner, bucket_id, name, vnode, req_id,
-            precondition, this.makeReleaseCb(rpcctx, cb));
+        objects.deleteObject(rpcctx, owner, bucket_id, name, vnode,
+            precondition, req_id, this.makeReleaseCb(rpcctx, cb));
     }
 };
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -704,9 +704,9 @@ BucketsMdapiClient.prototype.deleteBucket =
  *                                   which we are not immediately able to
  *                                   migrate the database to accommodate.
  * @param {Number} vnode           - Virtual node identifier
+ * @param {Object} conditions      - Object representing a set of conditional
+ *                                   parameters.
  * @param {String} req_id          - Request identifier
- * @param {Object} conditions      - Object representing a set of HTTP
- *                                   conditional headers.
  * @param {Function} cb            - callback
  */
 BucketsMdapiClient.prototype.createObject =
@@ -755,9 +755,9 @@ BucketsMdapiClient.prototype.createObject =
  *                                   which we are not immediately able to
  *                                   migrate the database to accommodate.
  * @param {Number} vnode           - Virtual node identifier
+ * @param {Object} conditions      - Object representing a set of conditional
+ *                                   parameters.
  * @param {String} req_id          - Request identifier
- * @param {Object} conditions      - Object representing a set of HTTP
- *                                   conditional headers.
  * @param {Function} cb            - callback
  */
 BucketsMdapiClient.prototype.updateObject =
@@ -794,9 +794,9 @@ BucketsMdapiClient.prototype.updateObject =
  * @param {String} bucket_id       - Bucket id
  * @param {String} name            - Object key name
  * @param {Number} vnode           - Virtual node identifier
+ * @param {Object} conditions      - Object representing a set of conditional
+ *                                   parameters.
  * @param {String} req_id          - Request identifier
- * @param {Object} conditions      - Object representing a set of HTTP
- *                                   conditional headers.
  * @param {Function} cb            - callback
  */
 BucketsMdapiClient.prototype.getObject =
@@ -858,9 +858,9 @@ BucketsMdapiClient.prototype.listObjects =
  * @param {String} bucket_id       - Bucket id
  * @param {String} name            - Object key name
  * @param {Number} vnode           - Virtual node identifier
+ * @param {Object} conditions      - Object representing a set of conditional
+ *                                   parameters.
  * @param {String} req_id          - Request identifier
- * @param {Object} conditions      - Object representing a set of HTTP
- *                                   conditional headers.
  * @param {Function} cb            - callback
  */
 BucketsMdapiClient.prototype.deleteObject =

--- a/lib/client.js
+++ b/lib/client.js
@@ -705,12 +705,20 @@ BucketsMdapiClient.prototype.deleteBucket =
  *                                   migrate the database to accommodate.
  * @param {Number} vnode           - Virtual node identifier
  * @param {String} req_id          - Request identifier
+ * @param {Object} precondition    - Optional object representing a set of HTTP
+ *                                   conditional headers.
  * @param {Function} cb            - callback
  */
 BucketsMdapiClient.prototype.createObject =
     function createObject(owner, bucket_id,
     name, object_id, content_length, content_md5, content_type, headers,
-    sharks, props, vnode, req_id, cb) {
+    sharks, props, vnode, req_id, precondition, cb) {
+
+    if (cb === undefined && typeof (precondition) === 'function') {
+        cb = precondition;
+        precondition = {};
+    }
+
     assert.string(owner, 'owner');
     assert.string(bucket_id, 'bucket_id');
     assert.string(name, 'name');
@@ -728,7 +736,7 @@ BucketsMdapiClient.prototype.createObject =
     if (rpcctx) {
         objects.createObject(rpcctx, owner, bucket_id, name, object_id,
             content_length, content_md5, content_type, headers, sharks, props,
-            vnode, req_id, this.makeReleaseCb(rpcctx, cb));
+            vnode, req_id, precondition, this.makeReleaseCb(rpcctx, cb));
     }
 };
 
@@ -752,11 +760,20 @@ BucketsMdapiClient.prototype.createObject =
  *                                   migrate the database to accommodate.
  * @param {Number} vnode           - Virtual node identifier
  * @param {String} req_id          - Request identifier
+ * @param {Object} precondition    - Optional object representing a set of HTTP
+ *                                   conditional headers.
  * @param {Function} cb            - callback
  */
 BucketsMdapiClient.prototype.updateObject =
     function updateObject(owner, bucket_id,
-    name, object_id, content_type, headers, props, vnode, req_id, cb) {
+    name, object_id, content_type, headers, props, vnode, req_id, precondition,
+    cb) {
+
+    if (cb === undefined && typeof (precondition) === 'function') {
+        cb = precondition;
+        precondition = {};
+    }
+
     assert.string(owner, 'owner');
     assert.string(bucket_id, 'bucket_id');
     assert.string(name, 'name');
@@ -765,12 +782,13 @@ BucketsMdapiClient.prototype.updateObject =
     assert.number(vnode, 'vnode');
     assert.optionalObject(props, 'props');
     assert.string(req_id, 'req_id');
+    assert.object(precondition, 'precondition');
     assert.func(cb, 'callback');
 
     var rpcctx = this.ctxCreateForCallback(cb);
     if (rpcctx) {
         objects.updateObject(rpcctx, owner, bucket_id, name, object_id,
-        content_type, headers, props, vnode, req_id,
+        content_type, headers, props, vnode, req_id, precondition,
         this.makeReleaseCb(rpcctx, cb));
     }
 };
@@ -786,22 +804,31 @@ BucketsMdapiClient.prototype.updateObject =
  * @param {String} name            - Object key name
  * @param {Number} vnode           - Virtual node identifier
  * @param {String} req_id          - Request identifier
+ * @param {Object} precondition    - Optional object representing a set of HTTP
+ *                                   conditional headers.
  * @param {Function} cb            - callback
  */
 BucketsMdapiClient.prototype.getObject =
-    function getObject(owner, bucket_id, name, vnode, req_id, cb) {
+    function getObject(owner, bucket_id, name, vnode, req_id, precondition,
+    cb) {
+
+    if (cb === undefined && typeof (precondition) === 'function') {
+        cb = precondition;
+        precondition = {};
+    }
 
     assert.string(owner, 'owner');
     assert.string(bucket_id, 'bucket_id');
     assert.string(name, 'name');
     assert.number(vnode, 'vnode');
     assert.string(req_id, 'req_id');
+    assert.object(precondition, 'precondition');
     assert.func(cb, 'callback');
 
     var rpcctx = this.ctxCreateForCallback(cb);
     if (rpcctx) {
         objects.getObject(rpcctx, owner, bucket_id, name, vnode, req_id,
-            this.makeReleaseCb(rpcctx, cb));
+            precondition, this.makeReleaseCb(rpcctx, cb));
     }
 };
 
@@ -846,22 +873,31 @@ BucketsMdapiClient.prototype.listObjects =
  * @param {String} name            - Object key name
  * @param {Number} vnode           - Virtual node identifier
  * @param {String} req_id          - Request identifier
+ * @param {Object} precondition    - Optional object representing a set of HTTP
+ *                                   conditional headers.
  * @param {Function} cb            - callback
  */
 BucketsMdapiClient.prototype.deleteObject =
-    function deleteObject(owner, bucket_id, name, vnode, req_id, cb) {
+    function deleteObject(owner, bucket_id, name, vnode, req_id, precondition,
+    cb) {
+
+    if (cb === undefined && typeof (precondition) === 'function') {
+        cb = precondition;
+        precondition = {};
+    }
 
     assert.string(owner, 'owner');
     assert.string(bucket_id, 'bucket_id');
     assert.string(name, 'name');
     assert.number(vnode, 'vnode');
     assert.string(req_id, 'req_id');
+    assert.object(precondition, 'precondition');
     assert.func(cb, 'callback');
 
     var rpcctx = this.ctxCreateForCallback(cb);
     if (rpcctx) {
         objects.deleteObject(rpcctx, owner, bucket_id, name, vnode, req_id,
-            this.makeReleaseCb(rpcctx, cb));
+            precondition, this.makeReleaseCb(rpcctx, cb));
     }
 };
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -705,14 +705,14 @@ BucketsMdapiClient.prototype.deleteBucket =
  *                                   migrate the database to accommodate.
  * @param {Number} vnode           - Virtual node identifier
  * @param {String} req_id          - Request identifier
- * @param {Object} precondition    - Optional object representing a set of HTTP
+ * @param {Object} conditions      - Object representing a set of HTTP
  *                                   conditional headers.
  * @param {Function} cb            - callback
  */
 BucketsMdapiClient.prototype.createObject =
     function createObject(owner, bucket_id,
     name, object_id, content_length, content_md5, content_type, headers,
-    sharks, props, vnode, precondition, req_id, cb) {
+    sharks, props, vnode, conditions, req_id, cb) {
 
     assert.string(owner, 'owner');
     assert.string(bucket_id, 'bucket_id');
@@ -725,14 +725,14 @@ BucketsMdapiClient.prototype.createObject =
     assert.number(vnode, 'vnode');
     assert.string(req_id, 'req_id');
     assert.optionalObject(props, 'props');
-    assert.optionalObject(precondition, 'precondition');
+    assert.optionalObject(conditions, 'conditions');
     assert.func(cb, 'callback');
 
     var rpcctx = this.ctxCreateForCallback(cb);
     if (rpcctx) {
         objects.createObject(rpcctx, owner, bucket_id, name, object_id,
             content_length, content_md5, content_type, headers, sharks, props,
-            vnode, precondition, req_id, this.makeReleaseCb(rpcctx, cb));
+            vnode, conditions, req_id, this.makeReleaseCb(rpcctx, cb));
     }
 };
 
@@ -756,13 +756,13 @@ BucketsMdapiClient.prototype.createObject =
  *                                   migrate the database to accommodate.
  * @param {Number} vnode           - Virtual node identifier
  * @param {String} req_id          - Request identifier
- * @param {Object} precondition    - Optional object representing a set of HTTP
+ * @param {Object} conditions      - Object representing a set of HTTP
  *                                   conditional headers.
  * @param {Function} cb            - callback
  */
 BucketsMdapiClient.prototype.updateObject =
     function updateObject(owner, bucket_id,
-    name, object_id, content_type, headers, props, vnode, precondition, req_id,
+    name, object_id, content_type, headers, props, vnode, conditions, req_id,
     cb) {
 
     assert.string(owner, 'owner');
@@ -773,13 +773,13 @@ BucketsMdapiClient.prototype.updateObject =
     assert.number(vnode, 'vnode');
     assert.optionalObject(props, 'props');
     assert.string(req_id, 'req_id');
-    assert.optionalObject(precondition, 'precondition');
+    assert.optionalObject(conditions, 'conditions');
     assert.func(cb, 'callback');
 
     var rpcctx = this.ctxCreateForCallback(cb);
     if (rpcctx) {
         objects.updateObject(rpcctx, owner, bucket_id, name, object_id,
-        content_type, headers, props, vnode, precondition, req_id,
+        content_type, headers, props, vnode, conditions, req_id,
         this.makeReleaseCb(rpcctx, cb));
     }
 };
@@ -795,25 +795,25 @@ BucketsMdapiClient.prototype.updateObject =
  * @param {String} name            - Object key name
  * @param {Number} vnode           - Virtual node identifier
  * @param {String} req_id          - Request identifier
- * @param {Object} precondition    - Optional object representing a set of HTTP
+ * @param {Object} conditions      - Object representing a set of HTTP
  *                                   conditional headers.
  * @param {Function} cb            - callback
  */
 BucketsMdapiClient.prototype.getObject =
-    function getObject(owner, bucket_id, name, vnode, precondition, req_id,
+    function getObject(owner, bucket_id, name, vnode, conditions, req_id,
     cb) {
 
     assert.string(owner, 'owner');
     assert.string(bucket_id, 'bucket_id');
     assert.string(name, 'name');
     assert.number(vnode, 'vnode');
-    assert.optionalObject(precondition, 'precondition');
+    assert.optionalObject(conditions, 'conditions');
     assert.string(req_id, 'req_id');
     assert.func(cb, 'callback');
 
     var rpcctx = this.ctxCreateForCallback(cb);
     if (rpcctx) {
-        objects.getObject(rpcctx, owner, bucket_id, name, vnode, precondition,
+        objects.getObject(rpcctx, owner, bucket_id, name, vnode, conditions,
             req_id, this.makeReleaseCb(rpcctx, cb));
     }
 };
@@ -859,12 +859,12 @@ BucketsMdapiClient.prototype.listObjects =
  * @param {String} name            - Object key name
  * @param {Number} vnode           - Virtual node identifier
  * @param {String} req_id          - Request identifier
- * @param {Object} precondition    - Optional object representing a set of HTTP
+ * @param {Object} conditions      - Object representing a set of HTTP
  *                                   conditional headers.
  * @param {Function} cb            - callback
  */
 BucketsMdapiClient.prototype.deleteObject =
-    function deleteObject(owner, bucket_id, name, vnode, precondition, req_id,
+    function deleteObject(owner, bucket_id, name, vnode, conditions, req_id,
     cb) {
 
     assert.string(owner, 'owner');
@@ -872,13 +872,13 @@ BucketsMdapiClient.prototype.deleteObject =
     assert.string(name, 'name');
     assert.number(vnode, 'vnode');
     assert.string(req_id, 'req_id');
-    assert.optionalObject(precondition, 'precondition');
+    assert.optionalObject(conditions, 'conditions');
     assert.func(cb, 'callback');
 
     var rpcctx = this.ctxCreateForCallback(cb);
     if (rpcctx) {
         objects.deleteObject(rpcctx, owner, bucket_id, name, vnode,
-            precondition, req_id, this.makeReleaseCb(rpcctx, cb));
+            conditions, req_id, this.makeReleaseCb(rpcctx, cb));
     }
 };
 

--- a/lib/objects.js
+++ b/lib/objects.js
@@ -61,7 +61,7 @@ function createObject(rpcctx, owner, bucket_id, name, object_id, content_length,
                 sharks: sharks,
                 properties: props,
                 precondition: precondition,
-                request_id: req_id,
+                request_id: req_id
               };
     log = rpc.childLogger(rpcctx, opts);
     rpc.rpcCommonSingleMessage({

--- a/lib/objects.js
+++ b/lib/objects.js
@@ -25,8 +25,8 @@ var rpc = require('./rpc');
 ///--- API
 
 function createObject(rpcctx, owner, bucket_id, name, object_id, content_length,
-    content_md5, content_type, headers, sharks, props, vnode, req_id,
-    precondition, callback) {
+    content_md5, content_type, headers, sharks, props, vnode, precondition,
+    req_id, callback) {
 
     var log;
 
@@ -43,8 +43,8 @@ function createObject(rpcctx, owner, bucket_id, name, object_id, content_length,
     assert.number(vnode, 'vnode');
     assert.func(callback, 'callback');
     assert.optionalObject(props, 'props');
+    assert.optionalObject(precondition, 'precondition');
     assert.string(req_id, 'req_id');
-    assert.object(precondition, 'precondition');
 
     var opts = {};
     opts.req_id = req_id;
@@ -60,8 +60,8 @@ function createObject(rpcctx, owner, bucket_id, name, object_id, content_length,
                 headers: headers,
                 sharks: sharks,
                 properties: props,
+                precondition: precondition,
                 request_id: req_id,
-                precondition: precondition
               };
     log = rpc.childLogger(rpcctx, opts);
     rpc.rpcCommonSingleMessage({
@@ -73,7 +73,7 @@ function createObject(rpcctx, owner, bucket_id, name, object_id, content_length,
     }, callback);
 }
 
-function getObject(rpcctx, owner, bucket_id, name, vnode, req_id, precondition,
+function getObject(rpcctx, owner, bucket_id, name, vnode, precondition, req_id,
     callback) {
 
     var log;
@@ -83,8 +83,8 @@ function getObject(rpcctx, owner, bucket_id, name, vnode, req_id, precondition,
     assert.string(bucket_id, 'bucket_id');
     assert.string(name, 'name');
     assert.number(vnode, 'vnode');
+    assert.optionalObject(precondition, 'precondition');
     assert.string(req_id, 'req_id');
-    assert.object(precondition, 'precondition');
     assert.func(callback, 'callback');
 
     var opts = {};
@@ -94,8 +94,8 @@ function getObject(rpcctx, owner, bucket_id, name, vnode, req_id, precondition,
                 bucket_id: bucket_id,
                 name: name,
                 vnode: vnode,
-                request_id: req_id,
-                precondition: precondition
+                precondition: precondition,
+                request_id: req_id
               };
 
     log = rpc.childLogger(rpcctx, opts);
@@ -109,7 +109,7 @@ function getObject(rpcctx, owner, bucket_id, name, vnode, req_id, precondition,
 }
 
 function updateObject(rpcctx, owner, bucket_id, name, object_id, content_type,
-    headers, props, vnode, req_id, precondition, callback) {
+    headers, props, vnode, precondition, req_id, callback) {
 
     var log;
 
@@ -123,8 +123,8 @@ function updateObject(rpcctx, owner, bucket_id, name, object_id, content_type,
     assert.number(vnode, 'vnode');
     assert.func(callback, 'callback');
     assert.optionalObject(props, 'props');
+    assert.optionalObject(precondition, 'precondition');
     assert.string(req_id, 'req_id');
-    assert.object(precondition, 'precondition');
 
     var opts = {};
     opts.req_id = req_id;
@@ -137,8 +137,8 @@ function updateObject(rpcctx, owner, bucket_id, name, object_id, content_type,
                 content_type: content_type,
                 headers: headers,
                 properties: props,
-                request_id: req_id,
-                precondition: precondition
+                precondition: precondition,
+                request_id: req_id
               };
     log = rpc.childLogger(rpcctx, opts);
     rpc.rpcCommonSingleMessage({
@@ -150,8 +150,8 @@ function updateObject(rpcctx, owner, bucket_id, name, object_id, content_type,
     }, callback);
 }
 
-function deleteObject(rpcctx, owner, bucket_id, name, vnode, req_id,
-    precondition, callback) {
+function deleteObject(rpcctx, owner, bucket_id, name, vnode, precondition,
+    req_id, callback) {
 
     var log;
 
@@ -160,9 +160,9 @@ function deleteObject(rpcctx, owner, bucket_id, name, vnode, req_id,
     assert.string(bucket_id, 'bucket_id');
     assert.string(name, 'name');
     assert.number(vnode, 'vnode');
+    assert.optionalObject(precondition, 'precondition');
     assert.string(req_id, 'req_id');
     assert.func(callback, 'callback');
-    assert.object(precondition, 'precondition');
 
     var opts = {};
     opts.req_id = req_id;
@@ -171,8 +171,9 @@ function deleteObject(rpcctx, owner, bucket_id, name, vnode, req_id,
                 bucket_id: bucket_id,
                 name: name,
                 vnode: vnode,
-                request_id: req_id,
-                precondition: precondition
+                precondition: precondition,
+                request_id: req_id
+
               };
 
     log = rpc.childLogger(rpcctx, opts);

--- a/lib/objects.js
+++ b/lib/objects.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright 2019 Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  */
 
 /*
@@ -26,7 +26,8 @@ var rpc = require('./rpc');
 
 function createObject(rpcctx, owner, bucket_id, name, object_id, content_length,
     content_md5, content_type, headers, sharks, props, vnode, req_id,
-    callback) {
+    precondition, callback) {
+
     var log;
 
     assert.object(rpcctx, 'rpcctx');
@@ -43,6 +44,7 @@ function createObject(rpcctx, owner, bucket_id, name, object_id, content_length,
     assert.func(callback, 'callback');
     assert.optionalObject(props, 'props');
     assert.string(req_id, 'req_id');
+    assert.object(precondition, 'precondition');
 
     var opts = {};
     opts.req_id = req_id;
@@ -58,7 +60,8 @@ function createObject(rpcctx, owner, bucket_id, name, object_id, content_length,
                 headers: headers,
                 sharks: sharks,
                 properties: props,
-                request_id: req_id
+                request_id: req_id,
+                precondition: precondition
               };
     log = rpc.childLogger(rpcctx, opts);
     rpc.rpcCommonSingleMessage({
@@ -70,7 +73,9 @@ function createObject(rpcctx, owner, bucket_id, name, object_id, content_length,
     }, callback);
 }
 
-function getObject(rpcctx, owner, bucket_id, name, vnode, req_id, callback) {
+function getObject(rpcctx, owner, bucket_id, name, vnode, req_id, precondition,
+    callback) {
+
     var log;
 
     assert.object(rpcctx, 'rpcctx');
@@ -79,6 +84,7 @@ function getObject(rpcctx, owner, bucket_id, name, vnode, req_id, callback) {
     assert.string(name, 'name');
     assert.number(vnode, 'vnode');
     assert.string(req_id, 'req_id');
+    assert.object(precondition, 'precondition');
     assert.func(callback, 'callback');
 
     var opts = {};
@@ -88,7 +94,8 @@ function getObject(rpcctx, owner, bucket_id, name, vnode, req_id, callback) {
                 bucket_id: bucket_id,
                 name: name,
                 vnode: vnode,
-                request_id: req_id
+                request_id: req_id,
+                precondition: precondition
               };
 
     log = rpc.childLogger(rpcctx, opts);
@@ -102,7 +109,8 @@ function getObject(rpcctx, owner, bucket_id, name, vnode, req_id, callback) {
 }
 
 function updateObject(rpcctx, owner, bucket_id, name, object_id, content_type,
-    headers, props, vnode, req_id, callback) {
+    headers, props, vnode, req_id, precondition, callback) {
+
     var log;
 
     assert.object(rpcctx, 'rpcctx');
@@ -116,6 +124,7 @@ function updateObject(rpcctx, owner, bucket_id, name, object_id, content_type,
     assert.func(callback, 'callback');
     assert.optionalObject(props, 'props');
     assert.string(req_id, 'req_id');
+    assert.object(precondition, 'precondition');
 
     var opts = {};
     opts.req_id = req_id;
@@ -128,7 +137,8 @@ function updateObject(rpcctx, owner, bucket_id, name, object_id, content_type,
                 content_type: content_type,
                 headers: headers,
                 properties: props,
-                request_id: req_id
+                request_id: req_id,
+                precondition: precondition
               };
     log = rpc.childLogger(rpcctx, opts);
     rpc.rpcCommonSingleMessage({
@@ -140,7 +150,9 @@ function updateObject(rpcctx, owner, bucket_id, name, object_id, content_type,
     }, callback);
 }
 
-function deleteObject(rpcctx, owner, bucket_id, name, vnode, req_id, callback) {
+function deleteObject(rpcctx, owner, bucket_id, name, vnode, req_id,
+    precondition, callback) {
+
     var log;
 
     assert.object(rpcctx, 'rpcctx');
@@ -150,6 +162,7 @@ function deleteObject(rpcctx, owner, bucket_id, name, vnode, req_id, callback) {
     assert.number(vnode, 'vnode');
     assert.string(req_id, 'req_id');
     assert.func(callback, 'callback');
+    assert.object(precondition, 'precondition');
 
     var opts = {};
     opts.req_id = req_id;
@@ -158,7 +171,8 @@ function deleteObject(rpcctx, owner, bucket_id, name, vnode, req_id, callback) {
                 bucket_id: bucket_id,
                 name: name,
                 vnode: vnode,
-                request_id: req_id
+                request_id: req_id,
+                precondition: precondition
               };
 
     log = rpc.childLogger(rpcctx, opts);

--- a/lib/objects.js
+++ b/lib/objects.js
@@ -25,7 +25,7 @@ var rpc = require('./rpc');
 ///--- API
 
 function createObject(rpcctx, owner, bucket_id, name, object_id, content_length,
-    content_md5, content_type, headers, sharks, props, vnode, precondition,
+    content_md5, content_type, headers, sharks, props, vnode, conditions,
     req_id, callback) {
 
     var log;
@@ -43,7 +43,7 @@ function createObject(rpcctx, owner, bucket_id, name, object_id, content_length,
     assert.number(vnode, 'vnode');
     assert.func(callback, 'callback');
     assert.optionalObject(props, 'props');
-    assert.optionalObject(precondition, 'precondition');
+    assert.optionalObject(conditions, 'conditions');
     assert.string(req_id, 'req_id');
 
     var opts = {};
@@ -60,7 +60,7 @@ function createObject(rpcctx, owner, bucket_id, name, object_id, content_length,
                 headers: headers,
                 sharks: sharks,
                 properties: props,
-                precondition: precondition,
+                conditions: conditions,
                 request_id: req_id
               };
     log = rpc.childLogger(rpcctx, opts);
@@ -73,7 +73,7 @@ function createObject(rpcctx, owner, bucket_id, name, object_id, content_length,
     }, callback);
 }
 
-function getObject(rpcctx, owner, bucket_id, name, vnode, precondition, req_id,
+function getObject(rpcctx, owner, bucket_id, name, vnode, conditions, req_id,
     callback) {
 
     var log;
@@ -83,7 +83,7 @@ function getObject(rpcctx, owner, bucket_id, name, vnode, precondition, req_id,
     assert.string(bucket_id, 'bucket_id');
     assert.string(name, 'name');
     assert.number(vnode, 'vnode');
-    assert.optionalObject(precondition, 'precondition');
+    assert.optionalObject(conditions, 'conditions');
     assert.string(req_id, 'req_id');
     assert.func(callback, 'callback');
 
@@ -94,7 +94,7 @@ function getObject(rpcctx, owner, bucket_id, name, vnode, precondition, req_id,
                 bucket_id: bucket_id,
                 name: name,
                 vnode: vnode,
-                precondition: precondition,
+                conditions: conditions,
                 request_id: req_id
               };
 
@@ -109,7 +109,7 @@ function getObject(rpcctx, owner, bucket_id, name, vnode, precondition, req_id,
 }
 
 function updateObject(rpcctx, owner, bucket_id, name, object_id, content_type,
-    headers, props, vnode, precondition, req_id, callback) {
+    headers, props, vnode, conditions, req_id, callback) {
 
     var log;
 
@@ -123,7 +123,7 @@ function updateObject(rpcctx, owner, bucket_id, name, object_id, content_type,
     assert.number(vnode, 'vnode');
     assert.func(callback, 'callback');
     assert.optionalObject(props, 'props');
-    assert.optionalObject(precondition, 'precondition');
+    assert.optionalObject(conditions, 'conditions');
     assert.string(req_id, 'req_id');
 
     var opts = {};
@@ -137,7 +137,7 @@ function updateObject(rpcctx, owner, bucket_id, name, object_id, content_type,
                 content_type: content_type,
                 headers: headers,
                 properties: props,
-                precondition: precondition,
+                conditions: conditions,
                 request_id: req_id
               };
     log = rpc.childLogger(rpcctx, opts);
@@ -150,7 +150,7 @@ function updateObject(rpcctx, owner, bucket_id, name, object_id, content_type,
     }, callback);
 }
 
-function deleteObject(rpcctx, owner, bucket_id, name, vnode, precondition,
+function deleteObject(rpcctx, owner, bucket_id, name, vnode, conditions,
     req_id, callback) {
 
     var log;
@@ -160,7 +160,7 @@ function deleteObject(rpcctx, owner, bucket_id, name, vnode, precondition,
     assert.string(bucket_id, 'bucket_id');
     assert.string(name, 'name');
     assert.number(vnode, 'vnode');
-    assert.optionalObject(precondition, 'precondition');
+    assert.optionalObject(conditions, 'conditions');
     assert.string(req_id, 'req_id');
     assert.func(callback, 'callback');
 
@@ -171,7 +171,7 @@ function deleteObject(rpcctx, owner, bucket_id, name, vnode, precondition,
                 bucket_id: bucket_id,
                 name: name,
                 vnode: vnode,
-                precondition: precondition,
+                conditions: conditions,
                 request_id: req_id
 
               };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "buckets-mdapi",
     "description": "Manta buckets metadata API client library",
-    "version": "0.6.0",
+    "version": "0.7.0",
     "author": "Joyent (joyent.com)",
     "keywords": [
         "manta",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "buckets-mdapi",
     "description": "Manta buckets metadata API client library",
-    "version": "0.5.0",
+    "version": "0.6.0",
     "author": "Joyent (joyent.com)",
     "keywords": [
         "manta",


### PR DESCRIPTION
This represents the minimum work required to pass conditional parameters to the buckets-mdapi service.

It's not backwards compatible, and while the `conditions` object is optional at buckets-mdapi, it is currently required in node-buckets-mdapi as an argument. This is similar to the `props` argument in some calls, where an empty object is required if these conditions are to be omitted.

I would love to make this `conditions` argument optional here, but I stopped when I realised that doing so is going to start getting messy. It can be done by moving `conditions` to a later position in the arguments and then doing something like:

```
if (!callback && typeof (conditions) === 'function') {
    callback = conditions;
    conditions = {};
    ...
```

... but at this point I think the signature of these methods should just be changed to take an object instead of a list of arguments.  This would make it much easier to check for optional arguments and provide a better interface for backwards compatibility.

I'd be interested to hear if others know of a reason for keeping these calls as an argument list, which I don't have a problem with if we have to. I can understand not doing this in node-moray because there are potentially more consumers, but I'm not sure how many consumers we have of node-buckets-mdapi and whether it's worth biting the bullet now to change the function signature.